### PR TITLE
Fix for iron bomber

### DIFF
--- a/gamedata/tf2-comp-fixes.games.txt
+++ b/gamedata/tf2-comp-fixes.games.txt
@@ -125,6 +125,22 @@
 					}
 				}
 			}
+
+			"CTFWeaponBaseGun::FirePipeBomb" {
+				// virtual CBaseEntity *FirePipeBomb( CTFPlayer *pPlayer, int iPipeBombType );
+				"signature" "CTFWeaponBaseGun::FirePipeBomb"
+				"callconv" "thiscall"
+				"return" "cbaseentity"
+				"this" "ignore"
+				"arguments" {
+					"player" {
+						"type" "objectptr"
+					}
+					"pipe_type" {
+						"type" "int"
+					}
+				}
+			}
 		}
 
 		"Keys" {
@@ -224,6 +240,18 @@
 			"GEconItemSchema" {
 				"linux" "@_Z15GEconItemSchemav"
 				"windows" "\xE8\x2A\x2A\x2A\x2A\x83\xC0\x04\xC3"
+			}
+
+			// contains string "projectile_spread_angle"
+			"CTFWeaponBaseGun::FirePipeBomb" {
+				"linux" "@_ZN16CTFWeaponBaseGun12FirePipeBombEP9CTFPlayeri"
+				"windows" "\x53\x8B\xDC\x83\xEC\x08\x83\xE4\xF0\x83\xC4\x04\x55\x8B\x6B\x04\x89\x6C\x24\x04\x8B\xEC\x81\xEC\x58\x01\x00\x00\x56\x8B\xF1\x57\x8B\x06"
+			}
+			
+			// is called from CCurrencyPack::Spawn (contains string "mvm_cash_embers_red")
+			"CBaseEntity::SetCollisionBounds" {
+				"linux" "@_ZN11CBaseEntity18SetCollisionBoundsERK6VectorS2_"
+				"windows" "\x55\x8B\xEC\x81\xC1\x5C\x01\x00\x00"
 			}
 		}
 	}

--- a/scripting/tf2-comp-fixes.sp
+++ b/scripting/tf2-comp-fixes.sp
@@ -26,6 +26,7 @@
 #include "tf2-comp-fixes/remove-pipe-spin.sp"
 #include "tf2-comp-fixes/tournament-end-ignores-whitelist.sp"
 #include "tf2-comp-fixes/winger-jump-bonus-when-fully-deployed.sp"
+#include "tf2-comp-fixes/fix-iron-bomber-hitbox.sp"
 
 #define PLUGIN_VERSION "1.10.5"
 
@@ -72,6 +73,7 @@ void OnPluginStart() {
     RemovePipeSpin_Setup();
     TournamentEndIgnoresWhitelist_Setup(game_config);
     WingerJumpBonusWhenFullyDeployed_Setup(game_config);
+    FixIronBomberHitbox_Setup(game_config);
 
     if (LibraryExists("updater")) {
         OnLibraryAdded("updater");
@@ -122,6 +124,7 @@ Action Command_Cf(int client, int args) {
         ReplyDiffConVar(client, "sm_remove_pipe_spin");
         ReplyDiffConVar(client, "sm_rest_in_peace_rick_may");
         ReplyDiffConVar(client, "sm_tournament_end_ignores_whitelist");
+        ReplyDiffConVar(client, "sm_fix_iron_bomber_hitbox");
         ReplyToCommand(client, "--- Balance changes");
         ReplyDiffConVar(client, "sm_gunboats_always_apply");
         ReplyDiffConVar(client, "sm_remove_medic_attach_speed");
@@ -162,6 +165,7 @@ Action Command_Cf(int client, int args) {
     FindConVar("sm_remove_pipe_spin").SetBool(all || fixes);
     FindConVar("sm_rest_in_peace_rick_may").SetInt(all || fixes || rgl ? 128 : ozf ? 255 : 0);
     FindConVar("sm_winger_jump_bonus_when_fully_deployed").SetBool(all || etf2l);
+    FindConVar("sm_fix_iron_bomber_hitbox").SetBool(all);
     PrintToChatAll("[TF2 Competitive Fixes] Successfully applied '%s' preset", full);
 
     return Plugin_Handled;

--- a/scripting/tf2-comp-fixes/fix-iron-bomber-hitbox.sp
+++ b/scripting/tf2-comp-fixes/fix-iron-bomber-hitbox.sp
@@ -1,0 +1,58 @@
+#define PIPE_SIZE 2.0
+
+static Handle g_call_CBaseEntity_SetCollisionBounds;
+static Handle g_detour_CTFWeaponBaseGun_FirePipeBomb;
+
+void FixIronBomberHitbox_Setup(Handle game_config) {
+    StartPrepSDKCall(SDKCall_Entity);
+
+    if (!PrepSDKCall_SetFromConf(game_config, SDKConf_Signature, "CBaseEntity::SetCollisionBounds")) {
+        SetFailState("Failed to finalize SDK call to BaseEntity::SetCollisionBounds");
+    }
+
+    PrepSDKCall_AddParameter(SDKType_Vector, SDKPass_ByRef);
+    PrepSDKCall_AddParameter(SDKType_Vector, SDKPass_ByRef);
+
+    g_call_CBaseEntity_SetCollisionBounds = EndPrepSDKCall();
+    g_detour_CTFWeaponBaseGun_FirePipeBomb = CheckedDHookCreateFromConf(game_config, "CTFWeaponBaseGun::FirePipeBomb");
+
+    CreateBoolConVar("sm_fix_iron_bomber_hitbox", OnConVarChange);
+}
+
+static void OnConVarChange(ConVar cvar, const char[] before, const char[] after) {
+    if (cvar.BoolValue == TruthyConVar(before)) {
+        return;
+    }
+
+    if (!DHookToggleDetour(g_detour_CTFWeaponBaseGun_FirePipeBomb, HOOK_POST,
+                           Detour_CTFWeaponBaseGun_FirePipeBomb, cvar.BoolValue)) {
+        SetFailState("Failed to toggle detour on CTFWeaponBaseGun::FirePipeBomb");
+    }
+}
+
+static MRESReturn Detour_CTFWeaponBaseGun_FirePipeBomb(Handle hReturn, Handle hParams) {
+    int entity = DHookGetReturn(hReturn);
+    
+    if (entity == -1) {
+        return MRES_Ignored;
+    }
+
+    float vec[3];
+    GetEntPropVector(entity, Prop_Data, "m_vecMaxs", vec);
+
+    if (vec[0] == PIPE_SIZE) {
+        return MRES_Ignored;
+    }
+
+    //PrintToServer("before %f", vec[0]);
+
+    float vecMins[3] = { -PIPE_SIZE, -PIPE_SIZE, -PIPE_SIZE };
+    float vecMaxs[3] = { PIPE_SIZE, PIPE_SIZE, PIPE_SIZE };
+
+    SDKCall(g_call_CBaseEntity_SetCollisionBounds, entity, vecMins, vecMaxs);
+
+    //GetEntPropVector(entity, Prop_Data, "m_vecMaxs", vec);
+    //PrintToServer("after %f", vec[0]);
+
+    return MRES_Handled;
+}


### PR DESCRIPTION
Added sm_fix_iron_bomber_hitbox command, it sets the iron bomber pipes size to the size of a stock ones. This fix also affects quickiebomb launcher stickies, but they ignore bounding boxes, so it shouldn't be a problem.
