### PR TITLE
fix pyro airblast explosive self damage (pipes , sentry rockets, flares)

### DIFF
--- a/gamedata/tf2-comp-fixes.games.txt
+++ b/gamedata/tf2-comp-fixes.games.txt
@@ -220,6 +220,19 @@
 					}
 				}
 			}
+			
+			"CTFFlameThrower::DeflectEntity" {
+				// virtual bool	DeflectEntity( CBaseEntity *pTarget, CTFPlayer *pOwner, Vector &vecForward, Vector &vecCenter, Vector &vecSize );
+				"signature"		"CTFFlameThrower::DeflectEntity"
+				"callconv"		"thiscall"
+				"return"		"bool"
+				"this"			"ignore"
+				"arguments" {
+					"projectile" {
+						"type"	"cbaseentity"
+					}
+				}
+			}
 		}
 
 		"Keys" {
@@ -356,6 +369,9 @@
 			"PointInRespawnRoom" {
 				"linux" "@_Z18PointInRespawnRoomPK11CBaseEntityRK6Vectorb"
 				"windows" "\x55\x8B\xEC\x53\x33\xDB\x56\x57"
+			}
+			"CTFFlameThrower::DeflectEntity" {
+				"linux"		"@_ZN15CTFFlameThrower13DeflectEntityEP11CBaseEntityP9CTFPlayerR6Vector"
 			}
 		}
 	}

--- a/scripting/tf2-comp-fixes.sp
+++ b/scripting/tf2-comp-fixes.sp
@@ -17,6 +17,7 @@
 #include "tf2-comp-fixes/debug.sp"
 #include "tf2-comp-fixes/deterministic-fall-damage.sp"
 #include "tf2-comp-fixes/empty-active-ubercharges-when-dropped.sp"
+#include "tf2-comp-fixes/fix-airblast-explosive-self-damage.sp"
 #include "tf2-comp-fixes/fix-ghost-crossbow-bolts.sp"
 #include "tf2-comp-fixes/fix-post-pause-state.sp"
 #include "tf2-comp-fixes/fix-slope-bug.sp"
@@ -71,6 +72,7 @@ void OnPluginStart() {
     Concede_Setup();
     DeterministicFallDamage_Setup(game_config);
     EmptyActiveUberchargesWhenDropped_Setup(game_config);
+    FixAirblastSelfDamage_Setup(game_config);
     FixGhostCrossbowBolts_Setup();
     FixPostPauseState_Setup();
     FixSlopeBug_Setup(game_config);
@@ -138,6 +140,7 @@ Action Command_Cf(int client, int args) {
         ReplyToCommand(client, "--- Fixes");
         ReplyDiffConVar(client, "sm_deterministic_fall_damage");
         ReplyDiffConVar(client, "sm_empty_active_ubercharges_when_dropped");
+        ReplyDiffConVar(client, "sm_fix_airblast_explosive_selfdamage");
         ReplyDiffConVar(client, "sm_fix_ghost_crossbow_bolts");
         ReplyDiffConVar(client, "sm_fix_post_pause_state");
         ReplyDiffConVar(client, "sm_fix_slope_bug");
@@ -192,6 +195,9 @@ Action Command_Cf(int client, int args) {
     FindConVar("sm_empty_active_ubercharges_when_dropped")
         .SetBool(all || fixes);
 
+    FindConVar("sm_fix_airblast_explosive_selfdamage")
+        .SetBool(all || fixes);
+        
     FindConVar("sm_fix_ghost_crossbow_bolts")
         .SetBool(all || fixes || etf2l || ozf || rgl);
 

--- a/scripting/tf2-comp-fixes/fix-airblast-explosive-self-damage.sp
+++ b/scripting/tf2-comp-fixes/fix-airblast-explosive-self-damage.sp
@@ -1,0 +1,45 @@
+static ConVar g_cvar;
+
+static Handle g_detour_CTFFlameThrower_DeflectEntity;
+
+void FixAirblastSelfDamage_Setup(Handle game_config)
+{
+	g_detour_CTFFlameThrower_DeflectEntity = CheckedDHookCreateFromConf(game_config, "CTFFlameThrower::DeflectEntity");
+	
+	g_cvar = CreateConVar("sm_fix_airblast_explosive_selfdamage", "0", _, FCVAR_NOTIFY, true, 0.0, true, 1.0);
+	
+	g_cvar.AddChangeHook(OnConVarChange);
+}
+
+static void OnConVarChange(ConVar cvar, const char[] before, const char[] after) {
+    if (cvar.BoolValue == TruthyConVar(before)) {
+        return;
+    }
+    
+    if (!DHookToggleDetour(g_detour_CTFFlameThrower_DeflectEntity, HOOK_POST,
+                           Detour_CTFFlameThrower_DeflectEntity, cvar.BoolValue)) {
+        SetFailState("Failed to toggle detour on CTFFlameThrower::DeflectEntity");
+    }
+}
+
+static MRESReturn Detour_CTFFlameThrower_DeflectEntity(Handle hReturn, Handle hParams)
+{
+	int projectile = DHookGetParam(hParams, 1);
+	if (!IsValidEntity(projectile)) {
+		return MRES_Ignored;
+	}
+	
+	char class[32];
+	GetEdictClassname(projectile, class, sizeof(class));
+	
+	if(StrEqual(class, "tf_projectile_pipe", false)) {
+		SetEntPropEnt(projectile, Prop_Send, "m_hLauncher", GetEntPropEnt(projectile, Prop_Send, "m_hOriginalLauncher"));
+		return MRES_Handled;
+	}
+	
+	if(StrEqual(class, "tf_projectile_sentryrocket", false)) {
+		SetEntPropEnt(projectile, Prop_Send, "m_hOriginalLauncher", -1);
+		return MRES_Handled;
+	}
+	return MRES_Ignored;
+}

--- a/scripting/tf2-comp-fixes/fix-airblast-explosive-self-damage.sp
+++ b/scripting/tf2-comp-fixes/fix-airblast-explosive-self-damage.sp
@@ -37,6 +37,11 @@ static MRESReturn Detour_CTFFlameThrower_DeflectEntity(Handle hReturn, Handle hP
 		return MRES_Handled;
 	}
 	
+	if(StrEqual(class, "tf_projectile_flare", false)) {
+		SetEntPropEnt(projectile, Prop_Send, "m_hLauncher", GetEntPropEnt(projectile, Prop_Send, "m_hOriginalLauncher"));
+		return MRES_Handled;
+	}
+	
 	if(StrEqual(class, "tf_projectile_sentryrocket", false)) {
 		SetEntPropEnt(projectile, Prop_Send, "m_hOriginalLauncher", -1);
 		return MRES_Handled;


### PR DESCRIPTION
Reflected Pipes, flares and sentry rockets deal up to 170 self-damage due to them using the flamethrowers dps value from scripts/tf_weapon_flamethrower.ctx

Rockets are unaffected by this since they use the rocket launchers damage value instead of the flamethrower.
Reflected rockets use m_hOriginalLaucher. Pipes and flares seem to use m_hLauncher which is the flamethrower.
The Sentry rockets m_hOriginalLauncher is also overwritten to the flamethrower as well on deflect.

I haven't taken a look for the windows sig yet. Since you want to deprecate windows support anyways i thought i'd create this pull request for you to take a look at.