### PR TITLE
Fixed pauses being detected incorrectly causing full ubers after pauses

### DIFF
--- a/scripting/tf2-comp-fixes.sp
+++ b/scripting/tf2-comp-fixes.sp
@@ -121,7 +121,7 @@ void OnLibraryAdded(const char[] name) {
 }
 
 public
-void OnMapStart() { FixPostPauseState_OnMapStart(); }
+void OnGameFrame() { FixPostPauseState_OnGameFrame(); }
 
 public
 void OnClientPutInServer(int client) {

--- a/scripting/tf2-comp-fixes/fix-post-pause-state.sp
+++ b/scripting/tf2-comp-fixes/fix-post-pause-state.sp
@@ -14,7 +14,21 @@ void FixPostPauseState_Setup() {
     CreateBoolConVar("sm_fix_post_pause_state", WhenConVarChange);
 }
 
-void FixPostPauseState_OnMapStart() { g_paused = false; }
+void FixPostPauseState_OnGameFrame()
+{
+    static float lastGameTime = -1.0;
+    float flCurrentGameTime = GetGameTime();
+
+    if (flCurrentGameTime == lastGameTime)
+    {
+        g_paused = true;
+    }
+    else
+    {
+        g_paused = false;
+        lastGameTime = flCurrentGameTime;
+    }
+}
 
 static void WhenConVarChange(ConVar cvar, const char[] before, const char[] after) {
     if (cvar.BoolValue == TruthyConVar(before)) {
@@ -68,8 +82,6 @@ static Action WhenPause(int author, const char[] command, int argc) {
                      client, g_medigun[client], medigun);
         }
     }
-
-    g_paused = !g_paused;
 
     return Plugin_Continue;
 }


### PR DESCRIPTION
The "fix-post-pause-state" feature assumes that the pause command always toggles pause on/off. However, this is not the case when using certain plugins, like [my pause plugin](https://github.com/F2/F2s-sourcemod-plugins/tree/master/pause). For example, when unpausing, it suppresses the pause command, and instead starts a countdown of 5 seconds before actually triggering the (un)pause command.

The result is that your plugin stores the state of the uber during the pause (which is often 100% due to it ticking up while paused), and then "restores" it to 100% when unpaused.

A very simple way to reproduce it:
1. Load both plugins (with `sm_fix_post_pause_state 1`)
2. Reload tf2-comp-fixes to ensure it is loaded last: `sm plugins reload tf2-comp-fixes`
3. Add a few bots so you have someone to heal: `rcon sv_cheats 1` and `rcon bot`
4. Switch to medic and start healing
5. In the console, execute "pause" twice really quickly - my plugin will block the second call
6. Wait a minute for the uber to charge during the pause state
7. Then execute "pause" again to unpause
8. If you paused at 5% uber, it will unpause at 100% uber

[Uber going to 100% after pause](https://github.com/user-attachments/assets/ccb46755-c78f-4720-bcc3-339b8fc65801)

For these plugins to work well together, you will need a better way to detect pauses.

In this PR, I am detecting it by looking at `GetGameTime()`. 
I have tested it by running your plugin alone, and running both plugins together - on both Windows and Linux servers.

I am slightly concerned about using `OnGameFrame()` since there could be a performance penalty. I tried using `IsServerProcessing()` but it seems to return _true_ sometimes even when paused. If you have a better idea for solving this problem, I am all ears.

