### PR TITLE
Updated windows signatures

### DIFF
--- a/gamedata/tf2-comp-fixes.games.txt
+++ b/gamedata/tf2-comp-fixes.games.txt
@@ -305,14 +305,14 @@
 			//
 			"CTFDroppedWeapon::InitDroppedWeapon" {
 				"linux" "@_ZN16CTFDroppedWeapon17InitDroppedWeaponEP9CTFPlayerP13CTFWeaponBasebb"
-				"windows" "\x55\x8B\xEC\x83\xEC\x30\x56\x57\x8B\xF9\x8B\x4D\x08"
+				"windows" "\x55\x8B\xEC\x83\xEC\x24\x56\x57\x8B\xF9\x8B\x4D\x08"
 			}
 
 			// contains string "BumperCar.JumpLand"
 			// multiple xrefs, it's the function that isn't just a bunch of strings
 			"CTFGameMovement::SetGroundEntity" {
 				"linux" "@_ZN15CTFGameMovement15SetGroundEntityEP10CGameTrace"
-				"windows" "\x55\x8B\xEC\x83\xEC\x0C\x56\x8B\xF1\x57\x8B\x7D\x08\x6A\x52"
+				"windows" "\x55\x8B\xEC\x56\x8B\xF1\x57\x8B\x7D\x2A\x6A\x52"
 			}
 
 			// contains string "uber_on_damage_taken"


### PR DESCRIPTION
Updated Windows gamedata for SetGroundEntity and InitDroppedWeapon.

Gamedata for SetGroundEntity found here: https://github.com/chrb22/jumpqol/commit/27104ab591a43db23d172d38fb22bfc193888bca
Gamedata for InitDroppedWeapon found here: https://github.com/Batfoxkid/Freak-Fortress-2-Rewrite/pull/259